### PR TITLE
Fix: 메인페이지 및 캘린더 수정

### DIFF
--- a/src/app/college/page.tsx
+++ b/src/app/college/page.tsx
@@ -1,11 +1,30 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import BranchHeader from '@/components/common/BranchHeader';
 import CollegeList from '@/components/features/branch/CollegeList';
+import Modal from '@/components/common/Modal';
 
 export default function CollegePage() {
+  const router = useRouter();
+  const isModalOpen = true;
+  const modalMessage = '소모임 페이지는 준비중입니다.';
+
+  const handleConfirm = () => {
+    router.back(); // 이전 화면으로 돌아가기
+  };
+
   return (
     <>
       <BranchHeader mainTitle="단과대" subTitle="단과대" />
       <CollegeList />
+      <Modal
+        isOpen={isModalOpen}
+        message={modalMessage}
+        onClose={handleConfirm}
+        onConfirm={() => {}}
+        showConfirmButton={false}
+      />
     </>
   );
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,26 +1,35 @@
 import { Button } from '@/components/ui/button';
 
 interface ModalProps {
+  isOpen: boolean;
   message: string;
   onClose: () => void;
   onConfirm: () => void;
   showConfirmButton: boolean;
 }
 
-export default function Modal({ message, onClose, onConfirm, showConfirmButton }: ModalProps) {
+export default function Modal({
+  isOpen,
+  message,
+  onClose,
+  onConfirm,
+  showConfirmButton,
+}: ModalProps) {
+  if (!isOpen) return null;
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white p-6 rounded-lg">
+      <div className="bg-white p-6 rounded-lg md:w-80 md:h-40 flex flex-col items-center justify-center">
         <p
           dangerouslySetInnerHTML={{ __html: message.replace(/\n/g, '<br/>') }}
           className="text-center px-6"
         />
-        <div className="flex flex-row items-center justify-center gap-2">
+        <div className="flex flex-row items-center justify-center gap-2 md:mt-1">
           <Button
             onClick={onClose}
             className={`mt-4 ${showConfirmButton ? 'bg-gray-300' : 'bg-primary'} px-8 hover:bg-primary/50`}
           >
-            {showConfirmButton ? '취소' : '닫기'}
+            {showConfirmButton ? '취소' : '확인'}
           </Button>
           {showConfirmButton && (
             <Button onClick={onConfirm} className="mt-4 px-8">

--- a/src/components/features/calendar/AlwaysCalendar.tsx
+++ b/src/components/features/calendar/AlwaysCalendar.tsx
@@ -14,10 +14,12 @@ interface AlwaysCalendarProps {
 export default function AlwaysCalendar({ alwaysCalendars, month }: AlwaysCalendarProps) {
   const [isCalendarModalOpen, setIsCalendarModalOpen] = useState(false);
   const [selectedClubId, setSelectedClubId] = useState<number | null>(null);
+  const [selectedCalendarNum, setSelectedCalendarNum] = useState<number>(0);
 
   const handleClubClick = async (calendar: AlwaysCalendarType) => {
     setIsCalendarModalOpen(true);
     setSelectedClubId(calendar.clubId);
+    setSelectedCalendarNum(calendar.calendarNum);
   };
 
   return (
@@ -35,7 +37,7 @@ export default function AlwaysCalendar({ alwaysCalendars, month }: AlwaysCalenda
             alwaysCalendars.map((calendar) => (
               <Button
                 key={calendar.clubId}
-                className="text-xs md:text-md w-fit px-2 py-0 md:py-0.5 justify-start rounded-md transition-colors bg-secondary text-gray-800 hover:bg-primary/70"
+                className="text-xs md:text-md w-fit px-2 py-0 md:py-0.5 justify-start rounded-md transition-colors bg-primary/30 text-gray-800 hover:bg-primary/70"
                 onClick={() => handleClubClick(calendar)}
               >
                 {calendar.clubName}
@@ -56,6 +58,7 @@ export default function AlwaysCalendar({ alwaysCalendars, month }: AlwaysCalenda
           onClose={() => setIsCalendarModalOpen(false)}
           isAlways={true}
           month={month}
+          calendarNum={selectedCalendarNum}
         />
       )}
     </div>

--- a/src/components/features/calendar/Calendar.tsx
+++ b/src/components/features/calendar/Calendar.tsx
@@ -34,6 +34,7 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [isDateModalOpen, setIsDateModalOpen] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const today = new Date();
   const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
@@ -49,6 +50,12 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
   const lastMonthLastDate = getDate(new Date(year, month - 1, 0));
 
   const totalCells = curMonthFirstDay + curMonthLastDate > 35 ? 42 : 35;
+
+  // 관리자 여부
+  useEffect(() => {
+    const adminStatus = localStorage.getItem('isAdmin');
+    setIsAdmin(adminStatus === 'true');
+  }, []);
 
   // 즐겨찾기 상태 가져오기
   useEffect(() => {
@@ -73,6 +80,9 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
       };
 
       fetchFavoriteStatuses();
+    } else if (!isLoggedIn) {
+      // 로그인하지 않은 경우 즐겨찾기 상태 초기화
+      setFavoriteStatuses({});
     }
   }, [isLoggedIn, nonAlwaysCalendars]);
 
@@ -272,7 +282,7 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
             return (
               <Card
                 key={i}
-                className={`flex flex-col p-1.5 h-[110px] rounded-sm gap-0 hover:shadow-md ${
+                className={`flex flex-col p-1.5 h-[110px] rounded-sm gap-0 hover:shadow-md scrollbar-hide ${
                   isCurrentMonth
                     ? 'bg-white hover:bg-white/80 transition-colors duration-300 cursor-pointer'
                     : 'bg-white/50'
@@ -317,13 +327,15 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
                             </span>
                             <span className="ml-1 break-words">{item.clubName}</span>
                           </div>
-                          <Star
-                            strokeWidth={2}
-                            color="#FFD000"
-                            fill={favoriteStatuses[item.clubId]?.isFavorite ? '#FFD000' : 'none'}
-                            className="size-4 mt-0.5 cursor-pointer transition-all duration-200 hover:scale-110"
-                            onClick={(e) => handleStarClick(item.clubId, e)}
-                          />
+                          {!isAdmin && (
+                            <Star
+                              strokeWidth={2}
+                              color="#FFD000"
+                              fill={favoriteStatuses[item.clubId]?.isFavorite ? '#FFD000' : 'none'}
+                              className="size-4 mt-0.5 cursor-pointer transition-all duration-200 hover:scale-110"
+                              onClick={(e) => handleStarClick(item.clubId, e)}
+                            />
+                          )}
                         </div>
                       );
                     })}
@@ -424,17 +436,19 @@ export default function Calendar({ calendarData, nonAlwaysCalendars }: CalendarP
                                 <div className="flex-1">
                                   <div className="flex flex-row items-center gap-2">
                                     <div className="font-medium text-gray-900">{item.clubName}</div>
-                                    <Star
-                                      strokeWidth={2}
-                                      color="#FFD000"
-                                      fill={
-                                        favoriteStatuses[item.clubId]?.isFavorite
-                                          ? '#FFD000'
-                                          : 'none'
-                                      }
-                                      className="size-4 mt-0.5 cursor-pointer transition-all duration-200 hover:scale-110"
-                                      onClick={(e) => handleStarClick(item.clubId, e)}
-                                    />
+                                    {!isAdmin && (
+                                      <Star
+                                        strokeWidth={2}
+                                        color="#FFD000"
+                                        fill={
+                                          favoriteStatuses[item.clubId]?.isFavorite
+                                            ? '#FFD000'
+                                            : 'none'
+                                        }
+                                        className="size-4 mt-0.5 cursor-pointer transition-all duration-200 hover:scale-110"
+                                        onClick={(e) => handleStarClick(item.clubId, e)}
+                                      />
+                                    )}
                                   </div>
                                   <div className="text-xs text-blue-600 mt-1">
                                     {new Date(item.startAt).toLocaleDateString()} ~{' '}

--- a/src/components/features/calendar/CalendarModal.tsx
+++ b/src/components/features/calendar/CalendarModal.tsx
@@ -12,6 +12,7 @@ interface CalendarModalProps {
   onClose: () => void;
   isAlways: boolean;
   month: number;
+  calendarNum?: number;
 }
 
 export default function CalendarModal({
@@ -20,6 +21,7 @@ export default function CalendarModal({
   onClose,
   isAlways,
   month,
+  calendarNum = 0,
 }: CalendarModalProps) {
   const [clubData, setClubData] = useState<CalendarClubData | null>(null);
   const [alwaysClubData, setAlwaysClubData] = useState<AlwaysNextClubData | null>(null);
@@ -37,14 +39,15 @@ export default function CalendarModal({
         setAllAlwaysData(response.data.content);
         setAlwaysClubData(response.data.content[0]);
         setHasNext(response.data.hasNext);
-        setSize(response.data.size + 1); // size + 1 = 실제 항목 개수 (size: 1이면 실제로는 2개)
+        // calendarNum + 1 = 실제 항목 개수 (calendarNum: 0이면 1개, 1이면 2개)
+        setSize(calendarNum + 1);
       } else {
         const response = await getCalendarClubData(clubId!);
         setClubData(response.data);
       }
     };
     fetchClubData();
-  }, [clubId, isOpen, isAlways, month]);
+  }, [clubId, isOpen, isAlways, month, calendarNum]);
 
   // 모집기간 포맷팅 함수
   const getRecruitmentPeriod = () => {

--- a/src/components/features/club/ClubInfo.tsx
+++ b/src/components/features/club/ClubInfo.tsx
@@ -220,7 +220,7 @@ export default function ClubInfo({ clubId }: ClubInfoProps) {
 
   return (
     <>
-      <div className="max-w-5xl mx-auto sm:mx-[10%] flex flex-col">
+      <div className="max-w-5xl mx-auto flex flex-col">
         <Card className="mx-10 mt-12 mb-17">
           <div className="flex flex-row items-center px-5">
             <Image
@@ -413,7 +413,7 @@ export default function ClubInfo({ clubId }: ClubInfoProps) {
                   height={800}
                   className="object-cover blur-xs mb-6 relative"
                 />
-                <div className="text-center absolute -bottom-40 left-50 md:-bottom-45 md:left-200 transform -translate-x-1/2 -translate-y-1/2 bg-transparent py-11 px-13 md:px-30">
+                <div className="text-center absolute -bottom-40 left-50 md:-bottom-45 md:left-225 transform -translate-x-1/2 -translate-y-1/2 bg-transparent py-11 px-13">
                   <p className="text-gray/900 font-taebaek text-2xl mb-4 font-medium">
                     리뷰 기능 9월 중순 OPEN ‼️
                   </p>

--- a/src/components/features/main/Banner.tsx
+++ b/src/components/features/main/Banner.tsx
@@ -91,7 +91,7 @@ export default function Banner() {
           {BANNERS.map((banner, idx) => (
             <CarouselItem key={banner.id}>
               <Link href={banner.url}>
-                <div className="w-full h-54 md:h-86 rounded-xl overflow-hidden flex items-center justify-center relative">
+                <div className="w-full h-48 md:h-86 rounded-xl overflow-hidden flex items-center justify-center relative">
                   <Image
                     src={banner.mobileSrc}
                     alt={banner.alt}

--- a/src/components/features/main/GoToNotion.tsx
+++ b/src/components/features/main/GoToNotion.tsx
@@ -4,8 +4,8 @@ import Link from 'next/link';
 export default function GoToNotion() {
   return (
     <div className="bg-black rounded-2xl text-white h-full flex flex-col justify-between">
-      <div className="text-center">
-        <h3 className="text-2xl font-extrabold pt-6 mb-6">
+      <div className="text-center h-full p-0 m-0">
+        <h3 className="text-2xl font-extrabold pt-6 mb-8">
           클러버가 <br /> 궁금하시다면?
         </h3>
 
@@ -18,7 +18,7 @@ export default function GoToNotion() {
 
         {/* SNS 섹션 */}
         <div className="flex justify-end">
-          <div className="w-64 bg-white rounded-tl-3xl p-2.5 pb-2">
+          <div className="w-64  bg-white rounded-tl-3xl p-2.5 shadow-none">
             <div className="flex items-center justify-center">
               <span className="text-md text-black font-semibold mr-3"># 클러버 SNS</span>
 

--- a/src/components/features/main/MainCalendar.tsx
+++ b/src/components/features/main/MainCalendar.tsx
@@ -37,7 +37,9 @@ export default function MainCalendar() {
   return (
     <Card className="p-6 h-full gap-4 md:gap-6">
       <div className="flex flex-row items-center justify-between">
-        <h3 className="text-md md:text-lg font-bold">오늘, 모집 마감 🔥</h3>
+        <Link href="/calendar" className="hover:text-primary transition-colors duration-300">
+          <h3 className="text-md md:text-lg font-bold">오늘, 모집 마감 🔥</h3>
+        </Link>
         <Link
           href="/calendar"
           className="size-10 cursor-pointer hover:bg-gray-200 transition-colors duration-300 rounded-full border-none flex items-center justify-center"

--- a/src/components/features/main/MainFaq.tsx
+++ b/src/components/features/main/MainFaq.tsx
@@ -1,31 +1,56 @@
+'use client';
+
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { getFaqListData } from '../community/api/faq';
+import { FaqItem } from '@/types/community/faqData';
 
 export default function MainFaq() {
-  const faqs = [
-    '해시태그 기반 검색 오류 해결 안내',
-    '동아리 가입 신청 방법은 어떻게 되나요?',
-    '모집글 작성 시 주의사항은 무엇인가요?',
-    '계정 정보 변경은 어디서 할 수 있나요?',
-  ];
+  const [faqs, setFaqs] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchFaqs = async () => {
+      try {
+        const response = await getFaqListData({ page: 0, size: 10 }); // 충분한 데이터 가져오기
+        // API 응답에서 4개만
+        const limitedFaqs = response.data.slice(0, 4);
+        setFaqs(limitedFaqs.map((faq: FaqItem) => faq.title));
+      } catch (error) {
+        console.error('FAQ 데이터 로딩 실패:', error);
+        // 에러 시 기본 데이터 사용
+        setFaqs([
+          '해시태그 기반 검색 오류 해결 안내',
+          '동아리 가입 신청 방법은 어떻게 되나요?',
+          '모집글 작성 시 주의사항은 무엇인가요?',
+          '계정 정보 변경은 어디서 할 수 있나요?',
+        ]);
+      }
+    };
+    fetchFaqs();
+  }, []);
 
   return (
     <div className="bg-white rounded-2xl px-4 h-full">
       <h3 className="text-[16px] md:text-lg font-bold text-gray-900 mb-6">자주 묻는 질문</h3>
 
-      <div className="space-y-4">
+      <div className="space-y-2">
         {faqs.map((faq, index) => (
           <div key={index} className="flex items-center gap-3">
-            <div className="p-2 bg-[#F4F4F4] rounded-sm flex items-center justify-center flex-shrink-0">
-              <Image src="/images/main-faq.png" alt="main-faq" width={14} height={14} />
+            <div className="p-2 bg-[#F4F4F4] rounded-sm flex items-center justify-center flex-shrink-0 mb-2">
+              <Image src="/images/main-faq.png" alt="main-faq" width={16} height={16} />
             </div>
-            <span className="text-[13px] md:text-sm text-gray-700 flex-1 hover:text-primary transition-colors">
+            <span
+              className={`text-[13px] md:text-sm text-gray-700 flex-1 hover:text-primary transition-colors border-b-[0.5px] border-[#808080] pb-3 ${
+                index === faqs.length - 1 ? 'border-transparent' : ''
+              }`}
+            >
               {faq}
             </span>
           </div>
         ))}
       </div>
 
-      <button className="mt-5.5 py-2.5 md:py-3 w-full border border-[#808080] rounded-lg text-[13px] md:text-sm text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2">
+      <button className="mt-1 py-2.5 md:py-3 w-full border border-[#808080] rounded-[8px] text-[13px] md:text-sm text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2">
         자주 묻는 질문 더보기
       </button>
     </div>

--- a/src/components/features/main/MainNotice.tsx
+++ b/src/components/features/main/MainNotice.tsx
@@ -1,33 +1,50 @@
+'use client';
+
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { getMainNotice } from './api/main';
+
+interface Notice {
+  noticeId: number;
+  title: string;
+  createdAt: string;
+}
 
 export default function MainNotice() {
-  const notices = [
-    '해시태그 기반 검색 오류 해결 안내',
-    '클러버 서비스 이용약관 개정 안내',
-    '동아리 모집글 작성 가이드 업데이트',
-    '시스템 점검 안내 (2024.01.15)',
-  ];
+  const [notices, setNotices] = useState<Notice[]>([]);
+
+  useEffect(() => {
+    const fetchNotices = async () => {
+      const notices = await getMainNotice();
+      setNotices(notices);
+    };
+    fetchNotices();
+  }, []);
 
   return (
     <div className="bg-white rounded-2xl px-4 h-full">
       <h3 className="text-[16px] md:text-lg font-bold text-gray-900 mb-6">공지사항</h3>
 
-      <div className="space-y-4">
-        {notices.map((notice, index) => (
-          <div key={index}>
+      <div className="space-y-2">
+        {notices.map((notice) => (
+          <div key={notice.noticeId}>
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-[#F4F4F4] rounded-sm flex items-center justify-center flex-shrink-0">
-                <Image src="/images/main-notice.png" alt="main-notice" width={15} height={15} />
+              <div className="p-2 bg-[#F4F4F4] rounded-sm flex items-center justify-center flex-shrink-0 mb-2">
+                <Image src="/images/main-notice.png" alt="main-notice" width={16} height={16} />
               </div>
-              <span className="text-[13px] md:text-sm text-gray-700 flex-1 hover:text-primary transition-colors">
-                {notice}
+              <span
+                className={`text-[13px] md:text-sm text-gray-700 flex-1 hover:text-primary transition-colors border-b-[0.5px] border-[#808080] pb-3 ${
+                  notice.noticeId === 1 ? 'border-transparent' : ''
+                }`}
+              >
+                {notice.title}
               </span>
             </div>
           </div>
         ))}
       </div>
 
-      <button className="mt-6 py-2.5 md:py-3 w-full border border-[#808080] rounded-lg text-[13px] md:text-sm text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2">
+      <button className="mt-1 py-2.5 md:py-3 w-full border border-[#808080] rounded-[8px] text-[13px] md:text-sm text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2">
         공지사항 더보기
       </button>
     </div>

--- a/src/components/features/main/api/main.ts
+++ b/src/components/features/main/api/main.ts
@@ -32,3 +32,25 @@ export const getMainCalendar = async () => {
     return null;
   }
 };
+
+// 메인 페이지 공지사항 조회
+export const getMainNotice = async () => {
+  const res = await apiClient.get('/v1/notices/main-page');
+  if (res.data.success) {
+    return res.data.data;
+  } else {
+    console.error(res.data.message);
+    return null;
+  }
+};
+
+// 메인 페이지 faq 조회
+// export const getMainFaq = async () => {
+//   const res = await apiClient.get('/v1/faqs/main-page');
+//   if (res.data.success) {
+//     return res.data.data;
+//   } else {
+//     console.error(res.data.message);
+//     return null;
+//   }
+// }

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -361,7 +361,7 @@ export default function Header() {
 
       {/* 모바일 네비게이션 */}
       <div className="md:hidden border-t border-gray-200 bg-white">
-        <nav className="flex justify-center items-center py-4 px-4 space-x-4 text-md font-semibold">
+        <nav className="flex justify-center items-center py-4 px-4 space-x-8 text-md font-semibold">
           <Link
             href="/summary"
             className={`text-gray-800 hover:text-primary transition-all duration-300 hover:scale-105 ${


### PR DESCRIPTION
- 메인페이지 공지사항 및 faq api 연동 및 디자인 반영
- 단과대 소모임 페이지 비활성화 및 모달 띄워주기
- 캘린더 관리자의 경우, 즐겨찾기 버튼 숨기기
- 비로그인 상태에서 캘린더 조회 시, 즐겨찾기 조회 api 호출 안되도록
- 모바일 네비게이션 탭 간격 수정
